### PR TITLE
Return the memory allocated by Direct Buffer to the OS without waitin…

### DIFF
--- a/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
+++ b/modules/kernel/src/org/apache/axis2/deployment/DescriptionBuilder.java
@@ -96,6 +96,11 @@ public class DescriptionBuilder implements DeploymentConstants {
     public OMElement buildOM() throws XMLStreamException {
         OMElement element = (OMElement) XMLUtils.toOM(descriptionStream);
         element.build();
+        try {
+            descriptionStream.close();
+        } catch(Exception e) {
+            throw new XMLStreamException(e);
+        }
         return element;
     }
 


### PR DESCRIPTION
Since Axis did not close the InputStream in the part reading axis2.conf from the classpath, I encountered a problem that the Direct Buffer was not released easily and OOM occurred due to lack of memory. Since there is no place that uses InputStream after parsing XML, there should be no problem even if it is closed here.