### PR TITLE
Also parse action from start-info and use axiom ContentType for parsing

### DIFF
--- a/modules/kernel/test/org/apache/axis2/kernel/TransportUtilsTest.java
+++ b/modules/kernel/test/org/apache/axis2/kernel/TransportUtilsTest.java
@@ -1,0 +1,27 @@
+package org.apache.axis2.kernel;
+
+import junit.framework.TestCase;
+import org.apache.axis2.context.MessageContext;
+
+import java.util.UUID;
+
+public class TransportUtilsTest extends TestCase {
+
+    private static final String ACTION_INSIDE_STARTINFO = "multipart/related; type=\"application/xop+xml\"; boundary=\"%s\"; start=\"<root.message@cxf.apache.org>\"; start-info=\"application/soap+xml; action=\\\"%s\\\"\"";
+    private static final String ACTION_OUTSIDE_STARTINFO = "Multipart/Related;boundary=MIME_boundary;type=\"application/xop+xml\";start=\"<mymessage.xml@example.org>\";start-info=\"application/soap+xml\"; action=\"%s\"";
+
+    public void testProcessContentTypeForAction() {
+
+        String soapAction = "http://www.example.com/ProcessData";
+        String contentType;
+        MessageContext msgContext = new MessageContext();
+
+        contentType = String.format(ACTION_INSIDE_STARTINFO, UUID.randomUUID().toString(), soapAction);
+        TransportUtils.processContentTypeForAction(contentType, msgContext);
+        assertEquals(soapAction, msgContext.getSoapAction());
+
+        contentType = String.format(ACTION_OUTSIDE_STARTINFO, soapAction);
+        TransportUtils.processContentTypeForAction(contentType, msgContext);
+        assertEquals(soapAction, msgContext.getSoapAction());
+    }
+}


### PR DESCRIPTION
The org.apache.axis2.transport.TransportUtils#processContentTypeForAction has been modified to use ContentType from org.apache.axiom.mime to parse the header. In addition it extracts the action also from start-info.
See https://www.w3.org/TR/xop10/