### PR TITLE
AXIS2-6049 static serialVersionUID for Exception

### DIFF
--- a/modules/codegen/src/org/apache/axis2/wsdl/codegen/emitter/AxisServiceBasedMultiLanguageEmitter.java
+++ b/modules/codegen/src/org/apache/axis2/wsdl/codegen/emitter/AxisServiceBasedMultiLanguageEmitter.java
@@ -1053,7 +1053,7 @@ public class AxisServiceBasedMultiLanguageEmitter implements Emitter {
                     (String) faultClassNameMap.get(key),
                     faultElement);
             addAttribute(doc, "serialVersionUID",
-                    String.valueOf(System.currentTimeMillis()),
+                    "1L",
                     faultElement);
 
             //added the base exception class name

--- a/modules/codegen/src/org/apache/axis2/wsdl/codegen/emitter/AxisServiceBasedMultiLanguageEmitter.java
+++ b/modules/codegen/src/org/apache/axis2/wsdl/codegen/emitter/AxisServiceBasedMultiLanguageEmitter.java
@@ -1053,7 +1053,7 @@ public class AxisServiceBasedMultiLanguageEmitter implements Emitter {
                     (String) faultClassNameMap.get(key),
                     faultElement);
             addAttribute(doc, "serialVersionUID",
-                    "1L",
+                    String.valueOf(1L),
                     faultElement);
 
             //added the base exception class name


### PR DESCRIPTION
serialVersionUID would change every generation and won't be useful then. Also not needed for SOAP. Use static 1L as serialVersionUID for Exception. This also allows build caches to be used.