### PR TITLE
Resolved https://issues.apache.org/jira/browse/AXIS2-5929

### DIFF
--- a/modules/json/src/org/apache/axis2/json/AbstractJSONOMBuilder.java
+++ b/modules/json/src/org/apache/axis2/json/AbstractJSONOMBuilder.java
@@ -86,7 +86,22 @@ public abstract class AbstractJSONOMBuilder implements Builder {
                 jsonString = requestURL.substring(index + 1);
                 reader = new StringReader(jsonString);
             } else {
-                throw new AxisFault("No JSON message received through HTTP GET or POST");
+                /*
+                 * Resolve https://issues.apache.org/jira/browse/AXIS2-5929
+                 * @author MARTI PAMIES SOLA
+                 * @since   2022-10-27 
+                 * Set JSON message from request URI if not present as parameter.
+                 * This allow requests like: .../ResoureName/ResourceID  or .../ResoureName
+                 * To be considered as valid and be able to return a specific resoruce or, all this type of resources
+                 * If not added this improvment, those request were considered as invalid and an exception was thrown.
+                 */
+            	String requestParam=requestURL;
+            	if (!(requestParam.equals(""))) {
+            		jsonString = requestParam;
+                    reader = new StringReader(jsonString);
+            	}else {
+        			throw new AxisFault("No JSON message received through HTTP GET or POST");
+            	}
             }
         } else {
             // Not sure where this is specified, but SOAPBuilder also determines the charset

--- a/modules/transport/http/src/org/apache/axis2/transport/http/util/RESTUtil.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/util/RESTUtil.java
@@ -38,8 +38,6 @@ import org.apache.axis2.engine.Handler;
 import org.apache.axis2.kernel.TransportUtils;
 import org.apache.axis2.kernel.http.HTTPConstants;
 import org.apache.axis2.transport.http.HTTPTransportUtils;
-import org.apache.commons.logging.Log;
-
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/transport/http/src/org/apache/axis2/transport/http/util/RESTUtil.java
+++ b/modules/transport/http/src/org/apache/axis2/transport/http/util/RESTUtil.java
@@ -38,12 +38,14 @@ import org.apache.axis2.engine.Handler;
 import org.apache.axis2.kernel.TransportUtils;
 import org.apache.axis2.kernel.http.HTTPConstants;
 import org.apache.axis2.transport.http.HTTPTransportUtils;
+import org.apache.commons.logging.Log;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javax.servlet.http.HttpServletRequest;
 /**
  *
  */
@@ -140,8 +142,21 @@ public class RESTUtil {
         try {
 
             if (contentType == null || "".equals(contentType)) {
-                contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
+                /*
+                 * Resolve https://issues.apache.org/jira/browse/AXIS2-5929
+                 * @author MARTI PAMIES SOLA
+                 * @since  2022-10-27 
+                 * If contentType is not provided (for example a GET request)
+                 * Test if client has indicated some mime type preference using Accept HTTP header.
+                 */
+                String acceptType=((HttpServletRequest)msgContext.getProperty(HTTPConstants.MC_HTTP_SERVLETREQUEST)).getHeader("Accept");
+                if (acceptType == null || "".equals(acceptType)) {
+                    contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
+                } else {
+                    contentType=acceptType;
+                }
             }
+            
 
             // set the required properties so that even if there is an error during the dispatch
             // phase the response message will be passed to the client well. 
@@ -192,7 +207,19 @@ public class RESTUtil {
         try {
 
             if (contentType == null || "".equals(contentType)) {
-                contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
+                /*
+                 * Resolve https://issues.apache.org/jira/browse/AXIS2-5929
+                 * @author MARTI PAMIES SOLA
+                 * @since  2022-10-27 
+                 * If contentType is not provided (for example a GET request)
+                 * Test if client has indicated some mime type preference using Accept HTTP header.
+                 */
+                String acceptType=((HttpServletRequest)msgContext.getProperty(HTTPConstants.MC_HTTP_SERVLETREQUEST)).getHeader("Accept");
+                if (acceptType == null || "".equals(acceptType)) {
+                    contentType = HTTPConstants.MEDIA_TYPE_X_WWW_FORM;
+                } else {
+                    contentType=acceptType;
+                }
             }
 
             // set the required properties so that even if there is an error during the dispatch


### PR DESCRIPTION
As described at https://issues.apache.org/jira/browse/AXIS2-5929, this improvement allows axis2 to manage REST Get Request where client preferred mime Type is set using HTTP Header, a common behaviour when using REST paradigm.