### PR TITLE
fix AXIS2-6041 (totalDigits Facet of XSD type short incorrectly treat…

### DIFF
--- a/modules/adb/src/org/apache/axis2/databinding/utils/ConverterUtil.java
+++ b/modules/adb/src/org/apache/axis2/databinding/utils/ConverterUtil.java
@@ -1289,9 +1289,14 @@ public class ConverterUtil {
      * @return 0 if equal , + value if greater than , - value if less than
      */
     public static int compare(int intValue, String value) {
-        int other = Integer.parseInt(value);
-        return intValue < other ? -1 : (intValue == other ? 0 : 1);
-
+        int param;
+        try {
+            NumberFormat nf = NumberFormat.getInstance();
+            param = nf.parse(value).intValue();
+        } catch (Exception e) {
+            throw new ObjectConversionException(e);
+        }
+        return intValue < param ? -1 : (intValue == param ? 0 : 1);
     }
 
     /**
@@ -1319,7 +1324,14 @@ public class ConverterUtil {
      * @return 0 if equal , + value if greater than , - value if less than
      */
     public static long compare(long longValue, String value) {
-        return longValue - Long.parseLong(value);
+        long param;
+        try {
+            NumberFormat nf = NumberFormat.getInstance();
+            param = nf.parse(value).longValue();
+        } catch (Exception e) {
+            throw new ObjectConversionException(e);
+        }
+        return longValue - param;
     }
 
     /**
@@ -1328,7 +1340,14 @@ public class ConverterUtil {
      * @return 0 if equal , + value if greater than , - value if less than
      */
     public static int compare(short shortValue, String value) {
-        return shortValue - Short.parseShort(value);
+        short param;
+        try {
+            NumberFormat nf = NumberFormat.getInstance();
+            param = nf.parse(value).shortValue();
+        } catch (Exception e) {
+            throw new ObjectConversionException(e);
+        }
+        return shortValue - param;
     }
 
     /**

--- a/modules/adb/test/org/apache/axis2/databinding/utils/ConverterUtilTest.java
+++ b/modules/adb/test/org/apache/axis2/databinding/utils/ConverterUtilTest.java
@@ -583,4 +583,46 @@ public class ConverterUtilTest extends TestCase {
         long result = ConverterUtil.compare(value, decimalNotationString);
         assertThat(result).isGreaterThanOrEqualTo(0L);
     }
+
+    public void testCompareLongIsLessThanTotalDigitsFacetRestriction() {
+        long value = 1L;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isLessThan(0L);
+    }
+
+    public void testCompareLongIsGreaterThanOrEqualToTotalDigitsFacetRestriction() {
+        long value = 10L;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isGreaterThanOrEqualTo(0L);
+    }
+
+    public void testCompareIntIsLessThanTotalDigitsFacetRestriction() {
+        int value = 1;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isLessThan(0);
+    }
+
+    public void testCompareIntIsGreaterThanOrEqualToTotalDigitsFacetRestriction() {
+        int value = 10;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isGreaterThanOrEqualTo(0);
+    }
+
+    public void testCompareShortIsLessThanTotalDigitsFacetRestriction() {
+        short value = 1;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isLessThan(0);
+    }
+
+    public void testCompareShortIsGreaterThanOrEqualToTotalDigitsFacetRestriction() {
+        short value = 10;
+        String totalDigitsFromXsd = "1";
+        String decimalNotationString = ConverterUtil.convertToStandardDecimalNotation(totalDigitsFromXsd).toPlainString();
+        assertThat(ConverterUtil.compare(value, decimalNotationString)).isGreaterThanOrEqualTo(0);
+    }
 }


### PR DESCRIPTION
…ed in databinding)

This change builds on commit bb10ab2, which fixed `compare(BigInteger, String)` for AXIS2-5724, to fix the other variations for `int`, `long`, and `short`.

These variations seem to be invoked by the generated Java code when using different base types, such as the following:

    <xsd:simpleType name="MyType">
      <xsd:restriction base="xsd:int">
        <xsd:totalDigits value="1"/>
      </xsd:restriction>
    </xsd:simpleType>

This change also adds test cases for the variations.