### PR TITLE
fix: possible infinite recursion in Options.getSoapVersionURI (#AXIS2-6043)

### DIFF
--- a/modules/kernel/src/org/apache/axis2/client/Options.java
+++ b/modules/kernel/src/org/apache/axis2/client/Options.java
@@ -486,7 +486,7 @@ public class Options implements Externalizable, SafeSerializable {
      * @return version
      */
     public String getSoapVersionURI() {
-        if (soapVersionURI == null && parent != null) {
+        if (soapVersionURI == null && parent != null && this != parent) {
             return parent.getSoapVersionURI();
         }
 


### PR DESCRIPTION
Added `this != parent` check to prevent infinite recursion in that case.