### PR TITLE
fix: remove minimum build version in idea plugin (#AXIS2-6037)

### DIFF
--- a/modules/tool/axis2-idea-plugin/plugin/META-INF/plugin.xml
+++ b/modules/tool/axis2-idea-plugin/plugin/META-INF/plugin.xml
@@ -34,9 +34,6 @@
     <!--  <vendor logo="/general/ijLogo.png">IntelliJ</vendor>-->
     <vendor email="deepal@apache.org">Deepal Jayasinghe</vendor>
 
-    <!-- the IDEA build number which works with plugin -->
-    <idea-version since-build="2000"/>
-
     <!-- Plugin's application components -->
     <application-components>
         <component>


### PR DESCRIPTION
The version was outdated and no longer works with current IDEs.