### PR TITLE
exclude `org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api`

### DIFF
--- a/modules/jaxws/pom.xml
+++ b/modules/jaxws/pom.xml
@@ -85,13 +85,17 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/modules/metadata/pom.xml
+++ b/modules/metadata/pom.xml
@@ -91,6 +91,10 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-tools</artifactId>
             <exclusions>

--- a/modules/saaj/pom.xml
+++ b/modules/saaj/pom.xml
@@ -91,9 +91,15 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>org.eclipse.jetty.ee9</groupId>
             <artifactId>jetty-ee9-nested</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/modules/testutils/pom.xml
+++ b/modules/testutils/pom.xml
@@ -67,9 +67,15 @@
             <groupId>org.eclipse.jetty.ee10</groupId>
             <artifactId>jetty-ee10-webapp</artifactId>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>org.eclipse.jetty.ee9</groupId>
             <artifactId>jetty-ee9-nested</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/modules/transport/http/src/test/java/org/apache/axis2/transport/http/mock/MockHttpServletResponse.java
+++ b/modules/transport/http/src/test/java/org/apache/axis2/transport/http/mock/MockHttpServletResponse.java
@@ -173,16 +173,6 @@ public class MockHttpServletResponse implements HttpServletResponse, OutTranspor
     }
 
     @Override
-    public String encodeUrl(String url) {
-        return null;
-    }
-
-    @Override
-    public String encodeRedirectUrl(String url) {
-        return null;
-    }
-
-    @Override
     public void sendError(int sc, String msg) throws IOException {
     }
 
@@ -192,6 +182,10 @@ public class MockHttpServletResponse implements HttpServletResponse, OutTranspor
 
     @Override
     public void sendRedirect(String location) throws IOException {
+    }
+
+    @Override
+    public void sendRedirect(String location, int sc, boolean clearBuffer) throws IOException {
     }
 
     @Override
@@ -209,10 +203,6 @@ public class MockHttpServletResponse implements HttpServletResponse, OutTranspor
 
     @Override
     public void setStatus(int sc) {
-    }
-
-    @Override
-    public void setStatus(int sc, String sm) {
     }
 
     @Override

--- a/modules/transport/testkit/pom.xml
+++ b/modules/transport/testkit/pom.xml
@@ -99,9 +99,15 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>org.eclipse.jetty.ee9</groupId>
             <artifactId>jetty-ee9-nested</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-jakarta-servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1278,6 +1278,11 @@
                                     <allowSnapshotRepositories>true</allowSnapshotRepositories>
                                     <allowSnapshotPluginRepositories>true</allowSnapshotPluginRepositories>
                                 </requireNoRepositories>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api</exclude>
+                                    </excludes>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
it is a duplicate dependency of `jakarta.servlet:jakarta.servlet-api`, having duplicate classes should be avoided.