### PR TITLE
AXIS2-6082 fix reproducible builds issues

### DIFF
--- a/modules/adb-codegen/pom.xml
+++ b/modules/adb-codegen/pom.xml
@@ -137,7 +137,6 @@
                                     <fileset dir="${basedir}/src/" includes="**/*.xsl" />
                                     <filterset begintoken="#" endtoken="#">
                                         <filter token="axisVersion" value="${project.version}" />
-                                        <filter token="today" value=" Built on : ${build.time}" />
                                     </filterset>
                                 </copy>
                             </target>

--- a/modules/adb-codegen/pom.xml
+++ b/modules/adb-codegen/pom.xml
@@ -130,9 +130,6 @@
                         <phase>process-resources</phase>
                         <configuration>
                             <target>
-                                <tstamp>
-                                    <format property="build.time" pattern="MMM dd, yyyy (hh:mm:ss z)" locale="en" />
-                                </tstamp>
                                 <copy toDir="${basedir}/target/classes/" overwrite="true" filtering="on">
                                     <fileset dir="${basedir}/src/" includes="**/*.xsl" />
                                     <filterset begintoken="#" endtoken="#">

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate-bean.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate-bean.xsl
@@ -49,7 +49,7 @@
  * <xsl:value-of select="$name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
             <xsl:if test="string-length(normalize-space(@package)) > 0">

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate-helpermode.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate-helpermode.xsl
@@ -46,7 +46,7 @@
  * <xsl:value-of select="$name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
             package <xsl:value-of select="@package"/>;

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/ADBBeanTemplate.xsl
@@ -27,7 +27,7 @@
  * <xsl:value-of select="$name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
         <xsl:if test="string-length(normalize-space(@package)) > 0">
@@ -72,7 +72,7 @@
  * <xsl:value-of select="$name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
         <xsl:if test="string-length(normalize-space(@package)) > 0">

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/CADBBeanTemplateHeader.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/CADBBeanTemplateHeader.xsl
@@ -32,7 +32,7 @@
         * <xsl:value-of select="$axis2_name"/>.h
         *
         * This file was auto-generated from WSDL
-        * by the Apache Axis2/Java version: #axisVersion# #today#
+        * by the Apache Axis2/Java version: #axisVersion#
         */
 
         #include &lt;stdio.h&gt;
@@ -89,7 +89,7 @@
         * <xsl:value-of select="$axis2_name"/>.h
         *
         * This file was auto-generated from WSDL
-        * by the Apache Axis2/Java version: #axisVersion# #today#
+        * by the Apache Axis2/Java version: #axisVersion#
         */
 
        /**
@@ -1087,7 +1087,7 @@
          * <xsl:value-of select="$axis2_name"/>.h
          *
          * This file was auto-generated from WSDL
-         * by the Apache Axis2/Java version: #axisVersion# #today#
+         * by the Apache Axis2/Java version: #axisVersion#
          */
 
         #include &lt;stdio.h&gt;

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/CADBBeanTemplateSource.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/CADBBeanTemplateSource.xsl
@@ -28,7 +28,7 @@
          * <xsl:value-of select="$axis2_name"/>.c
          *
          * This file was auto-generated from WSDL
-         * by the Apache Axis2/Java version: #axisVersion# #today#
+         * by the Apache Axis2/Java version: #axisVersion#
          */
          
         #include "<xsl:value-of select="$axis2_name"/>.h"
@@ -6617,7 +6617,7 @@
          * <xsl:value-of select="$axis2_name"/>.c
          *
          * This file was auto-generated from WSDL
-         * by the Apache Axis2/Java version: #axisVersion# #today#
+         * by the Apache Axis2/Java version: #axisVersion#
          */
 
         #include "<xsl:value-of select="$axis2_name"/>.h"

--- a/modules/adb-codegen/src/org/apache/axis2/schema/template/PlainBeanTemplate.xsl
+++ b/modules/adb-codegen/src/org/apache/axis2/schema/template/PlainBeanTemplate.xsl
@@ -27,7 +27,7 @@
  * <xsl:value-of select="$name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
         package <xsl:value-of select="@package"/>;
@@ -54,7 +54,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
         package <xsl:value-of select="@package"/>;

--- a/modules/adb/test/org/apache/axis2/databinding/ClientInfo.java
+++ b/modules/adb/test/org/apache/axis2/databinding/ClientInfo.java
@@ -21,7 +21,7 @@
  * ClientInfo.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
 package org.apache.axis2.databinding;

--- a/modules/adb/test/org/apache/axis2/databinding/CreateAccountRequest.java
+++ b/modules/adb/test/org/apache/axis2/databinding/CreateAccountRequest.java
@@ -21,7 +21,7 @@
  * CreateAccountRequest.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
 package org.apache.axis2.databinding;

--- a/modules/codegen/pom.xml
+++ b/modules/codegen/pom.xml
@@ -197,9 +197,6 @@
                         <phase>process-resources</phase>
                         <configuration>
                             <target>
-                                <tstamp>
-                                    <format property="build.time" pattern="MMM dd, yyyy (hh:mm:ss z)" locale="en" />
-                                </tstamp>
                                 <copy toDir="${basedir}/target/classes/" overwrite="true" filtering="on">
                                     <fileset dir="${basedir}/src/" includes="**/*.xsl" />
                                     <filterset begintoken="#" endtoken="#">

--- a/modules/codegen/pom.xml
+++ b/modules/codegen/pom.xml
@@ -204,7 +204,6 @@
                                     <fileset dir="${basedir}/src/" includes="**/*.xsl" />
                                     <filterset begintoken="#" endtoken="#">
                                         <filter token="axisVersion" value="${project.version}" />
-                                        <filter token="today" value=" Built on : ${build.time}" />
                                     </filterset>
                                 </copy>
                             </target>

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/ServiceSkeleton.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/ServiceSkeleton.xsl
@@ -36,7 +36,7 @@
          * <xsl:value-of select="@name"/>.c
          *
          * This file was auto-generated from WSDL for "<xsl:value-of select="$qname"/>" service
-         * by the Apache Axis2 version: #axisVersion# #today#
+         * by the Apache Axis2 version: #axisVersion#
          *  <xsl:value-of select="$skeletonname"/>
          */
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/ServiceXMLTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/ServiceXMLTemplate.xsl
@@ -22,7 +22,7 @@
 
     <xsl:template match="/">
         <xsl:comment> This file was auto-generated from WSDL </xsl:comment>
-        <xsl:comment> by the Apache Axis2 version: #axisVersion# #today# </xsl:comment>
+        <xsl:comment> by the Apache Axis2 version: #axisVersion# </xsl:comment>
         <xsl:apply-templates/>
     </xsl:template>
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/SkelHeaderTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/SkelHeaderTemplate.xsl
@@ -30,7 +30,7 @@
      * <xsl:value-of select="@name"/>.h
      *
      * This file was auto-generated from WSDL for "<xsl:value-of select="$qname"/>" service
-     * by the Apache Axis2/C version: #axisVersion# #today#
+     * by the Apache Axis2/C version: #axisVersion#
      * <xsl:value-of select="@name"/> Axis2/C skeleton for the axisService- Header file
      */
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/SkelSourceTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/SkelSourceTemplate.xsl
@@ -29,7 +29,7 @@
      * <xsl:value-of select="@name"/>.c
      *
      * This file was auto-generated from WSDL for "<xsl:value-of select="$qname"/>" service
-     * by the Apache Axis2/C version: #axisVersion# #today#
+     * by the Apache Axis2/C version: #axisVersion#
      * <xsl:value-of select="@name"/> Axis2/C skeleton for the axisService
      */
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/StubHeaderTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/StubHeaderTemplate.xsl
@@ -36,7 +36,7 @@
         * <xsl:value-of select="@name"/>.h
         *
         * This file was auto-generated from WSDL for "<xsl:value-of select="$qname"/>" service
-        * by the Apache Axis2/Java version: #axisVersion# #today#
+        * by the Apache Axis2/Java version: #axisVersion#
         */
 
         #ifndef <xsl:value-of select="$caps_name"/>_H

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/c/StubSourceTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/c/StubSourceTemplate.xsl
@@ -37,7 +37,7 @@
        * <xsl:value-of select="@name"/>.c
        *
        * This file was auto-generated from WSDL for "<xsl:value-of select="$qname"/>" service
-       * by the Apache Axis2/Java version: #axisVersion# #today#
+       * by the Apache Axis2/Java version: #axisVersion#
        */
 
       #include "<xsl:value-of select="@name"/>.h"

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/general/ServiceXMLTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/general/ServiceXMLTemplate.xsl
@@ -22,7 +22,7 @@
 
     <xsl:template match="/">
         <xsl:comment> This file was auto-generated from WSDL </xsl:comment>
-        <xsl:comment> by the Apache Axis2 version: #axisVersion# #today# </xsl:comment>
+        <xsl:comment> by the Apache Axis2 version: #axisVersion# </xsl:comment>
         <serviceGroup>
             <xsl:apply-templates/>
         </serviceGroup>

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/CallbackHandlerTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/CallbackHandlerTemplate.xsl
@@ -24,7 +24,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
     package <xsl:value-of select="@package"/>;

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/ExceptionTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/ExceptionTemplate.xsl
@@ -24,7 +24,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
 package <xsl:value-of select="@package"/>;

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/InterfaceImplementationTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/InterfaceImplementationTemplate.xsl
@@ -43,7 +43,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
         package <xsl:value-of select="$package"/>;
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/InterfaceTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/InterfaceTemplate.xsl
@@ -40,7 +40,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
 
     package <xsl:value-of select="$package"/>;

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsExceptionTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsExceptionTemplate.xsl
@@ -32,7 +32,7 @@ import <xsl:value-of select="@value"/>;</xsl:for-each>
  * <xsl:value-of select="@name"/>.java
  *
  * This class was auto-generated from WSDL.
- * Apache Axis2 version: #axisVersion# #today#
+ * Apache Axis2 version: #axisVersion#
  *
  */
 <xsl:for-each select="annotation">

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceClassTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceClassTemplate.xsl
@@ -37,7 +37,7 @@ import javax.xml.ws.Service;<!--<xsl:for-each select="importList/import">-->
  * <xsl:value-of select="@name"/>.java
  *
  * This class was auto-generated from WSDL.
- * Apache Axis2 version: #axisVersion# #today#
+ * Apache Axis2 version: #axisVersion#
  *
  */
 <xsl:for-each select="annotation">

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceEndpointInterfaceImplTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceEndpointInterfaceImplTemplate.xsl
@@ -27,7 +27,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This class was auto-generated from WSDL.
- * Apache Axis2 version: #axisVersion# #today#
+ * Apache Axis2 version: #axisVersion#
  */
 <xsl:for-each select="annotation">
     <xsl:variable name="annoparamcount" select="count(param)"/>

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceEndpointInterfaceTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceEndpointInterfaceTemplate.xsl
@@ -30,7 +30,7 @@ import <xsl:value-of select="@value"/>;</xsl:for-each>
  * <xsl:value-of select="@name"/>.java
  *
  * This class was auto-generated from WSDL.
- * Apache Axis2 version: #axisVersion# #today#
+ * Apache Axis2 version: #axisVersion#
  */
 <xsl:for-each select="annotation">
     <xsl:variable name="annoparamcount" select="count(param)"/>

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceXMLTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/JaxwsServiceXMLTemplate.xsl
@@ -22,7 +22,7 @@
 
     <xsl:template match="/">
         <xsl:comment> This file was auto-generated from WSDL </xsl:comment>
-        <xsl:comment> Apache Axis2 version: #axisVersion# #today# </xsl:comment>
+        <xsl:comment> Apache Axis2 version: #axisVersion# </xsl:comment>
         <serviceGroup>
             <xsl:apply-templates/>
         </serviceGroup>

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/MessageReceiverTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/MessageReceiverTemplate.xsl
@@ -38,7 +38,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
         package <xsl:value-of select="@package"/>;
 
@@ -322,7 +322,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
         package <xsl:value-of select="@package"/>;
 
@@ -440,7 +440,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
         package <xsl:value-of select="@package"/>;
 

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/SkeletonInterfaceTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/SkeletonInterfaceTemplate.xsl
@@ -24,7 +24,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
     package <xsl:value-of select="@package"/>;
     /**

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/SkeletonTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/SkeletonTemplate.xsl
@@ -24,7 +24,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
     package <xsl:value-of select="@package"/>;
     /**

--- a/modules/codegen/src/org/apache/axis2/wsdl/template/java/TestClassTemplate.xsl
+++ b/modules/codegen/src/org/apache/axis2/wsdl/template/java/TestClassTemplate.xsl
@@ -35,7 +35,7 @@
  * <xsl:value-of select="@name"/>.java
  *
  * This file was auto-generated from WSDL
- * by the Apache Axis2 version: #axisVersion# #today#
+ * by the Apache Axis2 version: #axisVersion#
  */
     package <xsl:value-of select="$package"/>;
 

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -212,9 +212,6 @@
                         <phase>process-resources</phase>
                         <configuration>
                             <target>
-                                <tstamp>
-                                    <format property="build.time" pattern="MMM dd, yyyy (hh:mm:ss z)" locale="en" />
-                                </tstamp>
                                 <filter token="axisVersion" value="${project.version}" />
                                 <copy toDir="${basedir}/target/classes/org/apache/axis2/i18n" overwrite="true" filtering="on" file="${basedir}/src/org/apache/axis2/i18n/resource.properties" />
                             </target>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -216,7 +216,6 @@
                                     <format property="build.time" pattern="MMM dd, yyyy (hh:mm:ss z)" locale="en" />
                                 </tstamp>
                                 <filter token="axisVersion" value="${project.version}" />
-                                <filter token="TODAY" value="${build.time}" />
                                 <copy toDir="${basedir}/target/classes/org/apache/axis2/i18n" overwrite="true" filtering="on" file="${basedir}/src/org/apache/axis2/i18n/resource.properties" />
                             </target>
                         </configuration>

--- a/modules/kernel/src/org/apache/axis2/i18n/resource.properties
+++ b/modules/kernel/src/org/apache/axis2/i18n/resource.properties
@@ -42,9 +42,7 @@
 # PROCESS.
 axisVersion=Apache Axis2 version: @axisVersion@
 axisVersionRaw=@axisVersion@
-axisBuiltOnRaw=@TODAY@
 axisUserAgent=Axis/@axisVersion@
-builtOn=Built on @TODAY@
 #############################################################################
 
 threadpoolshutdown=Thread pool is shut down.

--- a/modules/metadata/src/org/apache/axis2/jaxws/i18n/resource.properties
+++ b/modules/metadata/src/org/apache/axis2/jaxws/i18n/resource.properties
@@ -43,9 +43,7 @@
 # PROCESS.
 axisVersion=Apache Axis2 version: #axisVersion#
 axisVersionRaw=#axisVersion#
-axisBuiltOnRaw=#today#
 axisUserAgent=Axis/#axisVersion#
-builtOn=Built on #today#
 #############################################################################
 test01=This string is a test string 01.
 faultProcessingNotSupported=User fault processing is not supported. The @WebFault faultbean is missing for {0}

--- a/pom.xml
+++ b/pom.xml
@@ -1234,12 +1234,12 @@
                 <plugin>
                     <groupId>org.apache.axis2</groupId>
                     <artifactId>axis2-aar-maven-plugin</artifactId>
-                    <version>1.8.0</version>
+                    <version>2.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.axis2</groupId>
                     <artifactId>axis2-mar-maven-plugin</artifactId>
-                    <version>1.8.0</version>
+                    <version>2.0.0</version>
                 </plugin>
                 
                 <!-- No chicken and egg problem here because the plugin doesn't expose


### PR DESCRIPTION
tested by running classical `mvn install` followed by `mvn clean package artifact:compare` 

precisely the full command used is `mvn -Papache-release clean install -DskipTests -Dmaven.javadoc.skip -Dgpg.skip && mvn -Papache-release clean package -DskipTests -Dmaven.javadoc.skip -Dgpg.skip artifact:compare`

fixed the 2 root causes:
- injection of "now" in generated files
- upgrade axis2-aar-maven-plugin and axis2-mar-maven-plugin from 1.8.0 to 2.0.0 as version 2.0.0 has been updated to generate reproducible output in 29c5b77d998761f17358c89d6da0fee98e8aa6d8

with this PR merged, I hope that third-party rebuild will be ok for 2.0.1 https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/axis2/README.md