### PR TITLE
junit dependency should be in test scope

### DIFF
--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -118,9 +118,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <!--
             <scope>test</scope>
-	    -->
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
The JUnit dependency should be in the test scope, as it is a test artifact and should not appear in the production build. The test scope was commented out some time ago - I do not know the reason - but reinstating it is the correct approach.

I am kindly submitting a pull request to correct this issue.