### PR TITLE
Not  throw an exception when the client closes the connection

### DIFF
--- a/modules/transport/http/src/main/java/org/apache/axis2/transport/http/server/AxisHttpConnectionImpl.java
+++ b/modules/transport/http/src/main/java/org/apache/axis2/transport/http/server/AxisHttpConnectionImpl.java
@@ -229,7 +229,8 @@ public class AxisHttpConnectionImpl implements AxisHttpConnection {
         this.inbuffer.clear();
         final int i = this.inbuffer.readLine(headLine, this.in);
         if (i == -1) {
-            throw new IOException("readLine() from SessionInputBufferImpl returned -1 in method receiveRequest()");
+            //throw new IOException("readLine() from SessionInputBufferImpl returned -1 in method receiveRequest()");
+            return null;
         }
 
 	final Header[] headers = AbstractMessageParser.parseHeaders(

--- a/modules/transport/http/src/main/java/org/apache/axis2/transport/http/server/AxisHttpService.java
+++ b/modules/transport/http/src/main/java/org/apache/axis2/transport/http/server/AxisHttpService.java
@@ -151,7 +151,7 @@ public class AxisHttpService {
         try {
             request = conn.receiveRequest();
 	    if (request == null) {
-                LOG.error("AxisHttpService.handleRequest() returning on null request, will close the connection");
+                LOG.info("AxisHttpService.handleRequest() returning on null request, will close the connection");
                 conn.close();
                 return;
             }


### PR DESCRIPTION
Introducing the change added from HTTPCORE-677 to file https://github.com/apache/httpcomponents-core/blob/5.3.x/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/DefaultBHttpServerConnection.java#L144
