### PR TITLE
fix: update old bouncycastle dependency in testutils

### DIFF
--- a/modules/testutils/pom.xml
+++ b/modules/testutils/pom.xml
@@ -79,8 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1027,6 +1027,11 @@
                 <artifactId>aspectjweaver</artifactId>
                 <version>${aspectj.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.81</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Switch to the jdk 8 version of bouncycastle to avoid a [vulnerability](https://github.com/apache/axis-axis2-java-core/security/dependabot/44) (it's only used for tests, but still)