### PR TITLE
Eclipse updates, raise minimum required JDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ on:
 
 env:
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
-  BASE_JAVA_VERSION: 17
+  BASE_JAVA_VERSION: 21
   DEFAULT_JAVA_DISTRIBUTION: 'temurin'
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 21, 25 ]
+        java: [ 21, 25 ]
     name: "Java ${{ matrix.java }}"
     runs-on: ubuntu-24.04
     steps:

--- a/modules/samples/swagger-server/pom.xml
+++ b/modules/samples/swagger-server/pom.xml
@@ -40,8 +40,8 @@
     </description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <moshi.version>1.15.0</moshi.version>
     </properties>
@@ -120,8 +120,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
 

--- a/modules/samples/userguide/src/userguide/springbootdemo/pom.xml
+++ b/modules/samples/userguide/src/userguide/springbootdemo/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <spring-boot.version>3.4.3</spring-boot.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -920,7 +920,7 @@
 	    <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.ui.ide</artifactId>
-                <version>3.22.800</version>
+                <version>3.23.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,7 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.core.resources</artifactId>
-                <version>3.23.100</version>
+                <version>3.23.200</version>
             </dependency>
 	    <dependency>
                 <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -900,7 +900,7 @@
 	    <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.jface</artifactId>
-                <version>3.38.100</version>
+                <version>3.39.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -925,7 +925,7 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.ui.workbench</artifactId>
-                <version>3.137.0</version>
+                <version>3.138.0</version>
                 <exclusions>
 		    <!-- FIXME -->	
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -910,7 +910,7 @@
 	    <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.swt</artifactId>
-                <version>3.132.0</version>
+                <version>3.133.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -506,7 +506,7 @@
              http://maven.apache.org/plugins/maven-site-plugin/examples/creating-content.html -->
         <axis2_version>${project.version}</axis2_version>
         <project.build.outputTimestamp>2025-03-04T22:45:29Z</project.build.outputTimestamp>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <jacoco.version>0.8.14</jacoco.version>
         <asm.version>9.9.1</asm.version>
         <swagger.version>2.2.45</swagger.version>
@@ -1293,8 +1293,8 @@
                                     <version>3.6.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <!-- We require Java 17+ for the build, supporting up to Java 25 -->
-                                    <version>[17,26)</version>
+                                    <!-- We require Java 21+ for the build, supporting up to Java 25 -->
+                                    <version>[21,26)</version>
                                 </requireJavaVersion>
                                 <requireNoRepositories>
                                     <message>The POM must not include repository definitions since non Apache repositories threaten the build stability.</message>


### PR DESCRIPTION
The Eclipse platform has raised the minimum required JDK version to JDK 21. Since the policy of using the not-quite-latest LTS java release as the minimum seems to be catching on in the library landscape (which currently is JDK 21 LTS since JDK 25 LTS has been released late last year) I propose following the same strategy in axis2.