### PR TITLE
harden SOAPPart.setContent xml parser against xxe

### DIFF
--- a/modules/saaj/src/org/apache/axis2/saaj/SOAPPartImpl.java
+++ b/modules/saaj/src/org/apache/axis2/saaj/SOAPPartImpl.java
@@ -320,6 +320,11 @@ public class SOAPPartImpl extends SOAPPart {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
             XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            // Reject DTDs and external entities so a StreamSource carrying a
+            // DOCTYPE cannot pull in local files or remote URLs (XXE).
+            inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            inputFactory.setProperty(
+                    XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             XMLStreamReader reader;
 
             if (source instanceof StreamSource) {

--- a/modules/saaj/test/org/apache/axis2/saaj/SOAPPartTest.java
+++ b/modules/saaj/test/org/apache/axis2/saaj/SOAPPartTest.java
@@ -36,10 +36,15 @@ import jakarta.xml.soap.SOAPEnvelope;
 import jakarta.xml.soap.SOAPHeader;
 import jakarta.xml.soap.SOAPHeaderElement;
 import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.soap.SOAPException;
 import jakarta.xml.soap.SOAPPart;
 import jakarta.xml.soap.Text;
 import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.StringReader;
 import java.util.Iterator;
 
 /**
@@ -80,6 +85,35 @@ public class SOAPPartTest extends Assert {
         SOAPBody body = message.getSOAPBody();
         Iterator iter2 = body.getChildElements();
         getContents(iter2, "");
+    }
+
+    @Test
+    public void testSetContentRejectsExternalEntity() throws Exception {
+        File secret = File.createTempFile("saaj-xxe", ".txt");
+        secret.deleteOnExit();
+        String marker = "SAAJ_XXE_SECRET_MARKER";
+        try (FileWriter w = new FileWriter(secret)) {
+            w.write(marker);
+        }
+        String xml =
+                "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE x [ <!ENTITY xxe SYSTEM \"" + secret.toURI() + "\"> ]>\n" +
+                "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                "<soapenv:Body><item>&xxe;</item></soapenv:Body></soapenv:Envelope>";
+
+        SOAPMessage message = MessageFactory.newInstance().createMessage();
+        SOAPPart soapPart = message.getSOAPPart();
+        try {
+            soapPart.setContent(new StreamSource(new StringReader(xml)));
+            message.saveChanges();
+        } catch (SOAPException expected) {
+            // DTD rejected outright is also fine
+            return;
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        message.writeTo(out);
+        assertFalse("external entity must not be expanded into the message",
+                    out.toString("UTF-8").contains(marker));
     }
 
     public void getContents(Iterator iterator, String indent) {


### PR DESCRIPTION
1. SOAPPartImpl.setContent builds its XMLInputFactory with newInstance() and no other settings, so DTDs and external entities are left on.
2. when the Source is a StreamSource it's handed straight to that reader, so a body with a DOCTYPE + SYSTEM entity gets expanded — file:// reads or outbound URLs from the parser.

Set SUPPORT_DTD and IS_SUPPORTING_EXTERNAL_ENTITIES to false on the factory before it parses.

What happens if someone calls setContent with a StreamSource over an inbound stream? That's the documented SAAJ way to load a body, so the bytes are attacker reachable and the hardening has to live here rather than in the caller. Lines up with the recent WSDL/XSD XXE work that hardened the DOM path but didn't touch this StAX one. Added a SOAPPartTest case that points an external entity at a temp file and checks the contents never land in the message.